### PR TITLE
[#30] Add URL field to pointless feedback messages

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pointless_feedback (4.1.4)
+    pointless_feedback (4.1.5)
       airrecord (~> 1.0)
       jquery-rails (>= 4.0)
       rails (>= 4.0)

--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ Defaults to engine's namespace, e.g. `pointless_feedback_messages`.  Change to a
 **invalid_words:**
 List of words in the feedback description that would prevent an email from sending.
 
+**show_url_field:**
+Defaults to `false`. If set to `true`, will show an additional URL field in the form.
+
+**url_label:**
+Defaults to `URL`. The label for the URL field that will be shown if `show_url_field` is `true`.
+
 **google_captcha_site_key & google_captcha_secret_key:**
 If you'd like to block out the robots, set up a Google Captcha instance:
 

--- a/app/controllers/pointless_feedback/messages_controller.rb
+++ b/app/controllers/pointless_feedback/messages_controller.rb
@@ -29,7 +29,8 @@ module PointlessFeedback
         :email_address,
         :name,
         :topic,
-        :contact_info
+        :contact_info,
+        :url
       ])
     end
 

--- a/app/models/pointless_feedback/message.rb
+++ b/app/models/pointless_feedback/message.rb
@@ -35,7 +35,8 @@ module PointlessFeedback
             "Email"       => email_address,
             "Topic"       => topic,
             "Description" => description,
-            "Date"        => created_at.strftime("%m/%d/%y")
+            "Date"        => created_at.strftime("%m/%d/%y"),
+            "URL"         => url
           )
         rescue => e
           # ignore errors in production, last thing you want is a 500

--- a/app/views/pointless_feedback/feedback_mailer/feedback.html.erb
+++ b/app/views/pointless_feedback/feedback_mailer/feedback.html.erb
@@ -3,4 +3,7 @@ You've got feedback!
 <p>Name: <%= @message.name %></p>
 <p>Email Address: <%= @message.email_address %></p>
 <p>Topic: <%= @message.topic %></p>
+<% if PointlessFeedback.show_url_field %>
+  <p><%= PointlessFeedback.url_label %>: <%= @message.url %></p>
+<% end %>
 <p>Description: <%= @message.description %></p>

--- a/app/views/pointless_feedback/messages/new.html.erb
+++ b/app/views/pointless_feedback/messages/new.html.erb
@@ -45,6 +45,13 @@
       <%= f.select :topic, PointlessFeedback.message_topics, { :prompt => true } %>
     </div>
 
+    <% if PointlessFeedback.show_url_field %>
+      <div class="field">
+        <%= f.label :url, PointlessFeedback.url_label %>
+        <%= f.text_field :url %>
+      </div>
+    <% end %>
+
     <div class="field">
       <%= f.label :description %>
       <%= f.text_area :description %>

--- a/db/migrate/20220518205500_add_url_to_pointless_feedback_messages.rb
+++ b/db/migrate/20220518205500_add_url_to_pointless_feedback_messages.rb
@@ -1,0 +1,5 @@
+class AddUrlToPointlessFeedbackMessages < ActiveRecord::Migration
+  def change
+    add_column :pointless_feedback_messages, :url, :string
+  end
+end

--- a/lib/pointless_feedback.rb
+++ b/lib/pointless_feedback.rb
@@ -55,6 +55,12 @@ module PointlessFeedback
   mattr_accessor :invalid_words
   @@invalid_words = []
 
+  mattr_accessor :show_url_field
+  @@show_url_field = false
+
+  mattr_accessor :url_label
+  @@url_label = "URL"
+
   # Default way to setup PointlessFeedback. Run rails generate
   # pointless_feedback_install to create a fresh initializer with all
   # configuration values.

--- a/lib/pointless_feedback/version.rb
+++ b/lib/pointless_feedback/version.rb
@@ -1,3 +1,3 @@
 module PointlessFeedback
-  VERSION = "4.1.4"
+  VERSION = "4.1.5"
 end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20130501182659) do
+ActiveRecord::Schema.define(version: 20220518205500) do
 
   create_table "pointless_feedback_messages", force: :cascade do |t|
     t.string   "name"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 20130501182659) do
     t.text     "description"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "url"
   end
 
 end

--- a/test/factories/messages.rb
+++ b/test/factories/messages.rb
@@ -4,5 +4,6 @@ FactoryGirl.define do
     email_address 'developer@pointlesscorp.com'
     description   'Site is broke'
     topic         'Other'
+    url           'https://www.viget.com/'
   end
 end

--- a/test/functional/pointless_feedback/feedback_mailer_test.rb
+++ b/test/functional/pointless_feedback/feedback_mailer_test.rb
@@ -23,6 +23,18 @@ module PointlessFeedback
       assert_match "Description: #{@message.description}", @mail.body.encoded
     end
 
+    test "feedback email body with URL field" do
+      PointlessFeedback.show_url_field = true
+      PointlessFeedback.url_label = "Story URL"
+
+      assert_match "You've got feedback!", @mail.body.encoded
+      assert_match "Name: #{@message.name}", @mail.body.encoded
+      assert_match "Email Address: #{@message.email_address}", @mail.body.encoded
+      assert_match "Topic: #{@message.topic}", @mail.body.encoded
+      assert_match "Description: #{@message.description}", @mail.body.encoded
+      assert_match "Story URL: #{@message.url}", @mail.body.encoded
+    end
+
     test "feedback from email when set" do
       PointlessFeedback.from_email = 'from@example.com'
       @mail = FeedbackMailer.feedback(@message)


### PR DESCRIPTION
#### Addresses #30 and Storyboard issue [#172](https://github.com/vigetlabs/storyboard/issues/172)

- Adds a `url` field to `pointless_feedback_messages` table.
- Adds `show_url_field` and `url_label` as options to `PointlessFeedback` to take advantage of the new field.
- Adds URL to form and email template.